### PR TITLE
fix(git_push): replace force with force_with_lease

### DIFF
--- a/src/workflows/default/action/ta09_pull_push.rs
+++ b/src/workflows/default/action/ta09_pull_push.rs
@@ -41,8 +41,8 @@ impl ActionStep for PullAndPush {
                 let mut git_push = GitPush::new();
                 // Configure push options - you can customize these as needed
                 git_push
-                    .set_force_with_lease(false)
-                    .set_upstream_flag(false);
+                    .with_force_with_lease(false)
+                    .with_upstream_flag(false);
 
                 match git_push.execute() {
                     Ok(_) => {

--- a/src/workflows/default/action/ta09_pull_push.rs
+++ b/src/workflows/default/action/ta09_pull_push.rs
@@ -40,7 +40,9 @@ impl ActionStep for PullAndPush {
                 // Pull successful, now attempt push
                 let mut git_push = GitPush::new();
                 // Configure push options - you can customize these as needed
-                git_push.set_force(false).set_upstream_flag(false);
+                git_push
+                    .set_force_with_lease(false)
+                    .set_upstream_flag(false);
 
                 match git_push.execute() {
                     Ok(_) => {


### PR DESCRIPTION
Replaced the basic `force` flag with `force-with-lease` functionality to prevent accidental overwrites of remote changes.
Added ` force_with_lease: bool` and optional `force_with_lease_ref: Option<String>` field

**force_with_lease_ref**: allows specifying exact commit hash the remote should be at

