### PR TITLE
refactor authentication logic

### DIFF
--- a/src/events/git_clone.rs
+++ b/src/events/git_clone.rs
@@ -1,7 +1,7 @@
 use super::AtomicEvent;
 use crate::bgit_error::{BGitError, BGitErrorWorkflowType, NO_RULE, NO_STEP};
 use crate::rules::Rule;
-use git2::{Cred, CredentialType};
+use crate::utils::git_auth::setup_auth_callbacks;
 use std::env;
 use std::path::Path;
 
@@ -122,142 +122,10 @@ impl GitClone {
         }
     }
 
-    /// Set up authentication callbacks for git operations
-    fn setup_auth_callbacks() -> git2::RemoteCallbacks<'static> {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let mut callbacks = git2::RemoteCallbacks::new();
-        let attempt_count = Arc::new(AtomicUsize::new(0));
-
-        callbacks.credentials(move |url, username_from_url, allowed_types| {
-            let current_attempt = attempt_count.fetch_add(1, Ordering::SeqCst);
-            // Limit authentication attempts to prevent infinite loops
-            if current_attempt > 3 {
-                return Err(git2::Error::new(
-                    git2::ErrorCode::Auth,
-                    git2::ErrorClass::Net,
-                    "Maximum authentication attempts exceeded",
-                ));
-            }
-
-            // If SSH key authentication is allowed
-            if allowed_types.contains(CredentialType::SSH_KEY) {
-                if let Some(username) = username_from_url {
-                    // Try SSH agent first (most common and secure)
-                    match Cred::ssh_key_from_agent(username) {
-                        Ok(cred) => {
-                            return Ok(cred);
-                        }
-                        Err(e) => {
-                            println!("SSH agent failed: {}", e);
-                        }
-                    }
-
-                    // Try to find SSH keys in standard locations
-                    let home_dir = std::env::var("HOME")
-                        .or_else(|_| std::env::var("USERPROFILE"))
-                        .unwrap_or_else(|_| ".".to_string());
-
-                    let ssh_dir = Path::new(&home_dir).join(".ssh");
-
-                    // Common SSH key file names in order of preference
-                    let key_files = [
-                        ("id_ed25519", "id_ed25519.pub"),
-                        ("id_rsa", "id_rsa.pub"),
-                        ("id_ecdsa", "id_ecdsa.pub"),
-                        ("id_dsa", "id_dsa.pub"),
-                    ];
-
-                    for (private_name, public_name) in &key_files {
-                        let private_key = ssh_dir.join(private_name);
-                        let public_key = ssh_dir.join(public_name);
-
-                        if private_key.exists() {
-                            // Try with public key if it exists
-                            if public_key.exists() {
-                                match Cred::ssh_key(username, Some(&public_key), &private_key, None)
-                                {
-                                    Ok(cred) => {
-                                        return Ok(cred);
-                                    }
-                                    Err(e) => {
-                                        eprintln!("SSH key with public key failed: {}", e);
-                                    }
-                                }
-                            }
-
-                            // Try without public key
-                            match Cred::ssh_key(username, None, &private_key, None) {
-                                Ok(cred) => {
-                                    return Ok(cred);
-                                }
-                                Err(e) => {
-                                    eprintln!("SSH key without public key failed: {}", e);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    eprintln!("No username provided for SSH authentication");
-                }
-            }
-
-            // If username/password authentication is allowed (HTTPS)
-            if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-                // Try to get credentials from git config or environment
-                if let (Ok(username), Ok(password)) =
-                    (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
-                {
-                    return Cred::userpass_plaintext(&username, &password);
-                }
-
-                // For GitHub, you might want to use a personal access token
-                if url.contains("github.com") {
-                    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-                        return Cred::userpass_plaintext("git", &token);
-                    }
-                }
-            }
-
-            // Default authentication (tries default SSH key)
-            if allowed_types.contains(CredentialType::DEFAULT) {
-                match Cred::default() {
-                    Ok(cred) => {
-                        return Ok(cred);
-                    }
-                    Err(e) => {
-                        eprintln!("Default authentication failed: {}", e);
-                    }
-                }
-            }
-
-            Err(git2::Error::new(
-                git2::ErrorCode::Auth,
-                git2::ErrorClass::Net,
-                format!(
-                    "Authentication failed after {} attempts for {}. Available methods: {:?}",
-                    current_attempt + 1,
-                    url,
-                    allowed_types
-                ),
-            ))
-        });
-
-        // Set up certificate check callback for HTTPS
-        callbacks.certificate_check(|_cert, _host| {
-            // In production, you should properly validate certificates
-            // For now, we'll accept all certificates (not recommended for production)
-            Ok(git2::CertificateCheckStatus::CertificateOk)
-        });
-
-        callbacks
-    }
-
     /// Create fetch options with authentication
     fn create_fetch_options() -> git2::FetchOptions<'static> {
         let mut fetch_options = git2::FetchOptions::new();
-        fetch_options.remote_callbacks(Self::setup_auth_callbacks());
+        fetch_options.remote_callbacks(setup_auth_callbacks());
         fetch_options
     }
 }

--- a/src/events/git_pull.rs
+++ b/src/events/git_pull.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use super::AtomicEvent;
 use crate::bgit_error::{BGitError, BGitErrorWorkflowType, NO_RULE, NO_STEP};
 use crate::rules::Rule;
-use git2::{Cred, CredentialType, Repository};
+use crate::utils::git_auth::setup_auth_callbacks;
+use git2::Repository;
 
 pub struct GitPull {
     pub pre_check_rules: Vec<Box<dyn Rule + Send + Sync>>,
@@ -462,142 +463,10 @@ impl GitPull {
         Ok(())
     }
 
-    /// Set up authentication callbacks for git operations
-    fn setup_auth_callbacks() -> git2::RemoteCallbacks<'static> {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let mut callbacks = git2::RemoteCallbacks::new();
-        let attempt_count = Arc::new(AtomicUsize::new(0));
-
-        callbacks.credentials(move |url, username_from_url, allowed_types| {
-            let current_attempt = attempt_count.fetch_add(1, Ordering::SeqCst);
-            // Limit authentication attempts to prevent infinite loops
-            if current_attempt > 3 {
-                return Err(git2::Error::new(
-                    git2::ErrorCode::Auth,
-                    git2::ErrorClass::Net,
-                    "Maximum authentication attempts exceeded",
-                ));
-            }
-
-            // If SSH key authentication is allowed
-            if allowed_types.contains(CredentialType::SSH_KEY) {
-                if let Some(username) = username_from_url {
-                    // Try SSH agent first (most common and secure)
-                    match Cred::ssh_key_from_agent(username) {
-                        Ok(cred) => {
-                            return Ok(cred);
-                        }
-                        Err(e) => {
-                            println!("SSH agent failed: {}", e);
-                        }
-                    }
-
-                    // Try to find SSH keys in standard locations
-                    let home_dir = std::env::var("HOME")
-                        .or_else(|_| std::env::var("USERPROFILE"))
-                        .unwrap_or_else(|_| ".".to_string());
-
-                    let ssh_dir = Path::new(&home_dir).join(".ssh");
-
-                    // Common SSH key file names in order of preference
-                    let key_files = [
-                        ("id_ed25519", "id_ed25519.pub"),
-                        ("id_rsa", "id_rsa.pub"),
-                        ("id_ecdsa", "id_ecdsa.pub"),
-                        ("id_dsa", "id_dsa.pub"),
-                    ];
-
-                    for (private_name, public_name) in &key_files {
-                        let private_key = ssh_dir.join(private_name);
-                        let public_key = ssh_dir.join(public_name);
-
-                        if private_key.exists() {
-                            // Try with public key if it exists
-                            if public_key.exists() {
-                                match Cred::ssh_key(username, Some(&public_key), &private_key, None)
-                                {
-                                    Ok(cred) => {
-                                        return Ok(cred);
-                                    }
-                                    Err(e) => {
-                                        eprintln!("SSH key with public key failed: {}", e);
-                                    }
-                                }
-                            }
-
-                            // Try without public key
-                            match Cred::ssh_key(username, None, &private_key, None) {
-                                Ok(cred) => {
-                                    return Ok(cred);
-                                }
-                                Err(e) => {
-                                    eprintln!("SSH key without public key failed: {}", e);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    eprintln!("No username provided for SSH authentication");
-                }
-            }
-
-            // If username/password authentication is allowed (HTTPS)
-            if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-                // Try to get credentials from git config or environment
-                if let (Ok(username), Ok(password)) =
-                    (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
-                {
-                    return Cred::userpass_plaintext(&username, &password);
-                }
-
-                // For GitHub, you might want to use a personal access token
-                if url.contains("github.com") {
-                    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-                        return Cred::userpass_plaintext("git", &token);
-                    }
-                }
-            }
-
-            // Default authentication (tries default SSH key)
-            if allowed_types.contains(CredentialType::DEFAULT) {
-                match Cred::default() {
-                    Ok(cred) => {
-                        return Ok(cred);
-                    }
-                    Err(e) => {
-                        eprintln!("Default authentication failed: {}", e);
-                    }
-                }
-            }
-
-            Err(git2::Error::new(
-                git2::ErrorCode::Auth,
-                git2::ErrorClass::Net,
-                format!(
-                    "Authentication failed after {} attempts for {}. Available methods: {:?}",
-                    current_attempt + 1,
-                    url,
-                    allowed_types
-                ),
-            ))
-        });
-
-        // Set up certificate check callback for HTTPS
-        callbacks.certificate_check(|_cert, _host| {
-            // In production, you should properly validate certificates
-            // For now, we'll accept all certificates (not recommended for production)
-            Ok(git2::CertificateCheckStatus::CertificateOk)
-        });
-
-        callbacks
-    }
-
     /// Create fetch options with authentication
     fn create_fetch_options() -> git2::FetchOptions<'static> {
         let mut fetch_options = git2::FetchOptions::new();
-        fetch_options.remote_callbacks(Self::setup_auth_callbacks());
+        fetch_options.remote_callbacks(setup_auth_callbacks());
         fetch_options
     }
 }

--- a/src/events/git_push.rs
+++ b/src/events/git_push.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
-
 use super::AtomicEvent;
 use crate::bgit_error::{BGitError, BGitErrorWorkflowType, NO_RULE, NO_STEP};
 use crate::rules::Rule;
-use git2::{Cred, CredentialType, Repository};
+use crate::utils::git_auth::setup_auth_callbacks;
+use git2::Repository;
+use std::path::Path;
 
 pub struct GitPush {
     pub pre_check_rules: Vec<Box<dyn Rule + Send + Sync>>,
@@ -239,155 +239,10 @@ impl GitPush {
         Ok(())
     }
 
-    /// Set up authentication callbacks for git operations
-    fn setup_auth_callbacks() -> git2::RemoteCallbacks<'static> {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let mut callbacks = git2::RemoteCallbacks::new();
-        let attempt_count = Arc::new(AtomicUsize::new(0));
-
-        callbacks.credentials(move |url, username_from_url, allowed_types| {
-            let current_attempt = attempt_count.fetch_add(1, Ordering::SeqCst);
-            // Limit authentication attempts to prevent infinite loops
-            if current_attempt > 3 {
-                return Err(git2::Error::new(
-                    git2::ErrorCode::Auth,
-                    git2::ErrorClass::Net,
-                    "Maximum authentication attempts exceeded",
-                ));
-            }
-
-            // If SSH key authentication is allowed
-            if allowed_types.contains(CredentialType::SSH_KEY) {
-                if let Some(username) = username_from_url {
-                    // Try SSH agent first (most common and secure)
-                    match Cred::ssh_key_from_agent(username) {
-                        Ok(cred) => {
-                            return Ok(cred);
-                        }
-                        Err(e) => {
-                            println!("SSH agent failed: {}", e);
-                        }
-                    }
-
-                    // Try to find SSH keys in standard locations
-                    let home_dir = std::env::var("HOME")
-                        .or_else(|_| std::env::var("USERPROFILE"))
-                        .unwrap_or_else(|_| ".".to_string());
-
-                    let ssh_dir = Path::new(&home_dir).join(".ssh");
-
-                    // Common SSH key file names in order of preference
-                    let key_files = [
-                        ("id_ed25519", "id_ed25519.pub"),
-                        ("id_rsa", "id_rsa.pub"),
-                        ("id_ecdsa", "id_ecdsa.pub"),
-                        ("id_dsa", "id_dsa.pub"),
-                    ];
-
-                    for (private_name, public_name) in &key_files {
-                        let private_key = ssh_dir.join(private_name);
-                        let public_key = ssh_dir.join(public_name);
-
-                        if private_key.exists() {
-                            // Try with public key if it exists
-                            if public_key.exists() {
-                                match Cred::ssh_key(username, Some(&public_key), &private_key, None)
-                                {
-                                    Ok(cred) => {
-                                        return Ok(cred);
-                                    }
-                                    Err(e) => {
-                                        println!("SSH key with public key failed: {}", e);
-                                    }
-                                }
-                            }
-
-                            // Try without public key
-                            match Cred::ssh_key(username, None, &private_key, None) {
-                                Ok(cred) => {
-                                    return Ok(cred);
-                                }
-                                Err(e) => {
-                                    println!("SSH key without public key failed: {}", e);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    println!("No username provided for SSH authentication");
-                }
-            }
-
-            // If username/password authentication is allowed (HTTPS)
-            if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-                // Try to get credentials from git config or environment
-                if let (Ok(username), Ok(password)) =
-                    (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
-                {
-                    return Cred::userpass_plaintext(&username, &password);
-                }
-
-                // For GitHub, you might want to use a personal access token
-                if url.contains("github.com") {
-                    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-                        return Cred::userpass_plaintext("git", &token);
-                    }
-                }
-            }
-
-            // Default authentication (tries default SSH key)
-            if allowed_types.contains(CredentialType::DEFAULT) {
-                match Cred::default() {
-                    Ok(cred) => {
-                        return Ok(cred);
-                    }
-                    Err(e) => {
-                        println!("Default authentication failed: {}", e);
-                    }
-                }
-            }
-
-            Err(git2::Error::new(
-                git2::ErrorCode::Auth,
-                git2::ErrorClass::Net,
-                format!(
-                    "Authentication failed after {} attempts for {}. Available methods: {:?}",
-                    current_attempt + 1,
-                    url,
-                    allowed_types
-                ),
-            ))
-        });
-
-        // Add push update reference callback for better error reporting
-        callbacks.push_update_reference(|refname, status| match status {
-            Some(msg) => {
-                println!("Push failed for {}: {}", refname, msg);
-                Err(git2::Error::from_str(msg))
-            }
-            None => {
-                println!("Push successful for {}", refname);
-                Ok(())
-            }
-        });
-
-        // Set up certificate check callback for HTTPS
-        callbacks.certificate_check(|_cert, _host| {
-            // In production, you should properly validate certificates
-            // For now, we'll accept all certificates (not recommended for production)
-            println!("Certificate check for host: {}", _host);
-            Ok(git2::CertificateCheckStatus::CertificateOk)
-        });
-
-        callbacks
-    }
-
     /// Create push options with authentication
     fn create_push_options() -> git2::PushOptions<'static> {
         let mut push_options = git2::PushOptions::new();
-        push_options.remote_callbacks(Self::setup_auth_callbacks());
+        push_options.remote_callbacks(setup_auth_callbacks());
         push_options
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod hook_executor;
 mod rules;
 mod step;
 mod util;
+mod utils;
 mod workflow_queue;
 mod workflows;
 

--- a/src/utils/git_auth.rs
+++ b/src/utils/git_auth.rs
@@ -1,168 +1,218 @@
 use git2::{
     CertificateCheckStatus, Cred, CredentialType, Error, ErrorClass, ErrorCode, RemoteCallbacks,
 };
-use std::{
-    path::Path,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-};
+use log::debug;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
 
-pub fn setup_auth_callbacks() -> RemoteCallbacks<'static> {
-    let mut callbacks = RemoteCallbacks::new();
-    let attempt_count = Arc::new(AtomicUsize::new(0));
+fn try_ssh_agent_auth(username: &str) -> Result<Cred, Error> {
+    debug!("Attempting SSH agent authentication for user: {}", username);
 
-    callbacks.credentials(move |url, username_from_url, allowed_types| {
-        let current_attempt = attempt_count.fetch_add(1, Ordering::SeqCst);
-        println!(
-            "[DEBUG] Authentication attempt #{} for URL: {}",
-            current_attempt + 1,
-            url
-        );
-
-        // Limit authentication attempts to prevent infinite loops
-        if current_attempt > 3 {
-            println!("[DEBUG] Maximum authentication attempts exceeded");
-            return Err(Error::new(
-                ErrorCode::Auth,
-                ErrorClass::Net,
-                "Maximum authentication attempts exceeded",
-            ));
-        }
-
-        // If SSH key authentication is allowed
-        if allowed_types.contains(CredentialType::SSH_KEY) {
-            println!("[DEBUG] SSH_KEY authentication allowed");
-            if let Some(username) = username_from_url {
-                println!("[DEBUG] Username from URL: {}", username);
-
-                // match Cred::ssh_key_from_agent(username) {
-                //     Ok(cred) => {
-                //         return Ok(cred);
-                //     }
-                //     Err(e) => {
-                //         println!("SSH agent failed: {}", e);
-                //     }
-                // }
-
-                // Try to find SSH keys in standard locations
-                let home_dir = std::env::var("HOME")
-                    .or_else(|_| std::env::var("USERPROFILE"))
-                    .unwrap_or_else(|_| ".".to_string());
-                println!("[DEBUG] Home directory resolved to: {}", home_dir);
-
-                let ssh_dir = Path::new(&home_dir).join(".ssh");
-                println!("[DEBUG] Checking .ssh directory at: {:?}", ssh_dir);
-
-                // Common SSH key file names in order of preference
-                let key_files = [
-                    // ("id_ed25519", "id_ed25519.pub"),
-                    ("id_rsa", "id_rsa.pub"),
-                    // ("id_ecdsa", "id_ecdsa.pub"),
-                    // ("id_dsa", "id_dsa.pub"),
-                ];
-
-                for (private_name, public_name) in &key_files {
-                    let private_key = ssh_dir.join(private_name);
-                    let public_key = ssh_dir.join(public_name);
-                    println!(
-                        "[DEBUG] Trying key pair: {:?}, {:?}",
-                        private_key, public_key
-                    );
-
-                    if private_key.exists() {
-                        println!("[DEBUG] Found private key: {:?}", private_key);
-
-                        if public_key.exists() {
-                            println!("[DEBUG] Found public key: {:?}", public_key);
-                            match Cred::ssh_key(username, Some(&public_key), &private_key, None) {
-                                Ok(cred) => {
-                                    println!("[DEBUG] SSH key auth with public key succeeded");
-                                    return Ok(cred);
-                                }
-                                Err(e) => {
-                                    eprintln!("SSH key with public key failed: {}", e);
-                                }
-                            }
-                        }
-
-                        println!("[DEBUG] Trying SSH key without public key");
-                        match Cred::ssh_key(username, None, &private_key, None) {
-                            Ok(cred) => {
-                                println!("[DEBUG] SSH key auth without public key succeeded");
-                                return Ok(cred);
-                            }
-                            Err(e) => {
-                                eprintln!("SSH key without public key failed: {}", e);
-                            }
-                        }
-                    } else {
-                        println!("[DEBUG] Private key not found: {:?}", private_key);
-                    }
-                }
-            } else {
-                eprintln!("No username provided for SSH authentication");
-            }
-        }
-
-        // If username/password authentication is allowed (HTTPS)
-        if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-            println!("[DEBUG] USER_PASS_PLAINTEXT authentication allowed");
-
-            if let (Ok(username), Ok(password)) =
-                (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
-            {
-                println!("[DEBUG] Using GIT_USERNAME and GIT_PASSWORD from environment");
-                return Cred::userpass_plaintext(&username, &password);
-            }
-
-            if url.contains("github.com") {
-                println!("[DEBUG] URL contains github.com, checking for GITHUB_TOKEN");
-                if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-                    println!("[DEBUG] Using GITHUB_TOKEN from environment");
-                    return Cred::userpass_plaintext("git", &token);
-                } else {
-                    println!("[DEBUG] GITHUB_TOKEN not found in environment");
-                }
-            }
-        }
-
-        // Default authentication (tries default SSH key)
-        if allowed_types.contains(CredentialType::DEFAULT) {
-            println!("[DEBUG] Attempting default credentials");
-            match Cred::default() {
-                Ok(cred) => {
-                    println!("[DEBUG] Default credentials succeeded");
-                    return Ok(cred);
-                }
-                Err(e) => {
-                    eprintln!("Default authentication failed: {}", e);
-                }
-            }
-        }
-
-        println!(
-            "[DEBUG] Authentication failed after {} attempts for {}. Available methods: {:?}",
-            current_attempt + 1,
-            url,
-            allowed_types
-        );
-        Err(Error::new(
+    if std::env::var("SSH_AUTH_SOCK").is_err() {
+        debug!("SSH_AUTH_SOCK not set, skipping ssh_key_from_agent");
+        return Err(Error::new(
             ErrorCode::Auth,
             ErrorClass::Net,
-            format!(
-                "Authentication failed after {} attempts for {}. Available methods: {:?}",
-                current_attempt + 1,
-                url,
-                allowed_types
-            ),
-        ))
+            "SSH_AUTH_SOCK not available",
+        ));
+    }
+
+    match Cred::ssh_key_from_agent(username) {
+        Ok(cred) => {
+            debug!("SSH agent authentication succeeded");
+            Ok(cred)
+        }
+        Err(e) => {
+            debug!("SSH agent authentication failed: {}", e);
+            Err(e)
+        }
+    }
+}
+
+fn try_ssh_key_files(
+    username: &str,
+    key_index: usize,
+    use_public_key: bool,
+) -> Result<Cred, Error> {
+    debug!(
+        "Attempting SSH key file authentication for user: {}, key_index: {}, use_public_key: {}",
+        username, key_index, use_public_key
+    );
+
+    let home_dir = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    debug!("Home directory resolved to: {}", home_dir);
+
+    let ssh_dir = Path::new(&home_dir).join(".ssh");
+    debug!("Checking .ssh directory at: {:?}", ssh_dir);
+
+    // Common SSH key file names in order of preference
+    let key_files = [
+        ("id_ed25519", "id_ed25519.pub"),
+        ("id_rsa", "id_rsa.pub"),
+        ("id_ecdsa", "id_ecdsa.pub"),
+        ("id_dsa", "id_dsa.pub"),
+    ];
+
+    if key_index >= key_files.len() {
+        debug!("Key index {} out of range", key_index);
+        return Err(Error::new(
+            ErrorCode::Auth,
+            ErrorClass::Net,
+            "All SSH key files exhausted",
+        ));
+    }
+
+    let (private_name, public_name) = key_files[key_index];
+    let private_key = ssh_dir.join(private_name);
+    let public_key = ssh_dir.join(public_name);
+
+    if !private_key.exists() {
+        debug!("Private key not found: {:?}", private_key);
+        return Err(Error::new(
+            ErrorCode::Auth,
+            ErrorClass::Net,
+            format!("Private key not found: {}", private_name),
+        ));
+    }
+
+    debug!("Found private key: {:?}", private_key);
+
+    if use_public_key {
+        if public_key.exists() {
+            debug!("Found public key: {:?}, trying with public key", public_key);
+            match Cred::ssh_key(username, Some(&public_key), &private_key, None) {
+                Ok(cred) => {
+                    debug!(
+                        "SSH key auth with public key succeeded for {}",
+                        private_name
+                    );
+                    Ok(cred)
+                }
+                Err(e) => {
+                    debug!("SSH key with public key failed for {}: {}", private_name, e);
+                    Err(e)
+                }
+            }
+        } else {
+            debug!(
+                "Public key not found for {}, skipping this attempt",
+                private_name
+            );
+            Err(Error::new(
+                ErrorCode::Auth,
+                ErrorClass::Net,
+                format!("Public key not found for {}", private_name),
+            ))
+        }
+    } else {
+        debug!("Trying SSH key without public key for {}", private_name);
+        match Cred::ssh_key(username, None, &private_key, None) {
+            Ok(cred) => {
+                debug!(
+                    "SSH key auth without public key succeeded for {}",
+                    private_name
+                );
+                Ok(cred)
+            }
+            Err(e) => {
+                debug!(
+                    "SSH key without public key failed for {}: {}",
+                    private_name, e
+                );
+                Err(e)
+            }
+        }
+    }
+}
+
+fn authenticate_git(
+    url: &str,
+    username_from_url: Option<&str>,
+    allowed_types: CredentialType,
+    attempt_count: usize,
+) -> Result<Cred, Error> {
+    debug!(
+        "Git authentication attempt #{} for URL: {}",
+        attempt_count, url
+    );
+    debug!("Username from URL: {:?}", username_from_url);
+    debug!("Allowed credential types: {:?}", allowed_types);
+
+    // Prevent infinite loops
+    if attempt_count > 20 {
+        debug!(
+            "Too many authentication attempts ({}), failing to prevent infinite loop",
+            attempt_count
+        );
+        return Err(Error::new(
+            ErrorCode::Auth,
+            ErrorClass::Net,
+            "Too many authentication attempts",
+        ));
+    }
+
+    // Try SSH key authentication if allowed
+    if allowed_types.contains(CredentialType::SSH_KEY) {
+        if let Some(username) = username_from_url {
+            debug!("SSH key authentication is allowed, trying SSH methods");
+
+            // Try SSH agent first (only on first attempt)
+            if attempt_count == 1 {
+                if let Ok(cred) = try_ssh_agent_auth(username) {
+                    return Ok(cred);
+                }
+                // If SSH agent fails, fall through to try SSH key files on same attempt
+            }
+
+            // Try SSH key files with progression
+            // Attempt 1+: Start with id_ed25519 if SSH agent failed
+            // Attempt 1: id_ed25519 with public key
+            // Attempt 2: id_ed25519 without public key
+            // Attempt 3: id_rsa with public key
+            // Attempt 4: id_rsa without public key
+            // etc.
+            let key_attempt = attempt_count - 1;
+            let key_index = key_attempt / 2;
+            let use_public_key = key_attempt % 2 == 0;
+
+            if let Ok(cred) = try_ssh_key_files(username, key_index, use_public_key) {
+                return Ok(cred);
+            }
+        } else {
+            debug!("No username provided for SSH authentication");
+        }
+    }
+
+    debug!(
+        "All authentication methods failed for attempt {}",
+        attempt_count
+    );
+    Err(Error::new(
+        ErrorCode::Auth,
+        ErrorClass::Net,
+        format!("Authentication failed - attempt {}", attempt_count),
+    ))
+}
+pub fn setup_auth_callbacks() -> RemoteCallbacks<'static> {
+    let mut callbacks = RemoteCallbacks::new();
+
+    // Track attempt count across callback invocations
+    let attempt_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+
+    callbacks.credentials(move |url, username_from_url, allowed_types| {
+        let mut count = attempt_count.lock().unwrap();
+        *count += 1;
+        let current_attempt = *count;
+        drop(count);
+
+        authenticate_git(url, username_from_url, allowed_types, current_attempt)
     });
 
     // Set up certificate check callback for HTTPS
     callbacks.certificate_check(|_cert, _host| {
-        println!("[DEBUG] Skipping certificate verification (INSECURE)");
+        debug!("Skipping certificate verification (INSECURE)");
         Ok(CertificateCheckStatus::CertificateOk)
     });
 

--- a/src/utils/git_auth.rs
+++ b/src/utils/git_auth.rs
@@ -1,0 +1,170 @@
+use git2::{
+    CertificateCheckStatus, Cred, CredentialType, Error, ErrorClass, ErrorCode, RemoteCallbacks,
+};
+use std::{
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+pub fn setup_auth_callbacks() -> RemoteCallbacks<'static> {
+    let mut callbacks = RemoteCallbacks::new();
+    let attempt_count = Arc::new(AtomicUsize::new(0));
+
+    callbacks.credentials(move |url, username_from_url, allowed_types| {
+        let current_attempt = attempt_count.fetch_add(1, Ordering::SeqCst);
+        println!(
+            "[DEBUG] Authentication attempt #{} for URL: {}",
+            current_attempt + 1,
+            url
+        );
+
+        // Limit authentication attempts to prevent infinite loops
+        if current_attempt > 3 {
+            println!("[DEBUG] Maximum authentication attempts exceeded");
+            return Err(Error::new(
+                ErrorCode::Auth,
+                ErrorClass::Net,
+                "Maximum authentication attempts exceeded",
+            ));
+        }
+
+        // If SSH key authentication is allowed
+        if allowed_types.contains(CredentialType::SSH_KEY) {
+            println!("[DEBUG] SSH_KEY authentication allowed");
+            if let Some(username) = username_from_url {
+                println!("[DEBUG] Username from URL: {}", username);
+
+                // match Cred::ssh_key_from_agent(username) {
+                //     Ok(cred) => {
+                //         return Ok(cred);
+                //     }
+                //     Err(e) => {
+                //         println!("SSH agent failed: {}", e);
+                //     }
+                // }
+
+                // Try to find SSH keys in standard locations
+                let home_dir = std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .unwrap_or_else(|_| ".".to_string());
+                println!("[DEBUG] Home directory resolved to: {}", home_dir);
+
+                let ssh_dir = Path::new(&home_dir).join(".ssh");
+                println!("[DEBUG] Checking .ssh directory at: {:?}", ssh_dir);
+
+                // Common SSH key file names in order of preference
+                let key_files = [
+                    // ("id_ed25519", "id_ed25519.pub"),
+                    ("id_rsa", "id_rsa.pub"),
+                    // ("id_ecdsa", "id_ecdsa.pub"),
+                    // ("id_dsa", "id_dsa.pub"),
+                ];
+
+                for (private_name, public_name) in &key_files {
+                    let private_key = ssh_dir.join(private_name);
+                    let public_key = ssh_dir.join(public_name);
+                    println!(
+                        "[DEBUG] Trying key pair: {:?}, {:?}",
+                        private_key, public_key
+                    );
+
+                    if private_key.exists() {
+                        println!("[DEBUG] Found private key: {:?}", private_key);
+
+                        if public_key.exists() {
+                            println!("[DEBUG] Found public key: {:?}", public_key);
+                            match Cred::ssh_key(username, Some(&public_key), &private_key, None) {
+                                Ok(cred) => {
+                                    println!("[DEBUG] SSH key auth with public key succeeded");
+                                    return Ok(cred);
+                                }
+                                Err(e) => {
+                                    eprintln!("SSH key with public key failed: {}", e);
+                                }
+                            }
+                        }
+
+                        println!("[DEBUG] Trying SSH key without public key");
+                        match Cred::ssh_key(username, None, &private_key, None) {
+                            Ok(cred) => {
+                                println!("[DEBUG] SSH key auth without public key succeeded");
+                                return Ok(cred);
+                            }
+                            Err(e) => {
+                                eprintln!("SSH key without public key failed: {}", e);
+                            }
+                        }
+                    } else {
+                        println!("[DEBUG] Private key not found: {:?}", private_key);
+                    }
+                }
+            } else {
+                eprintln!("No username provided for SSH authentication");
+            }
+        }
+
+        // If username/password authentication is allowed (HTTPS)
+        if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
+            println!("[DEBUG] USER_PASS_PLAINTEXT authentication allowed");
+
+            if let (Ok(username), Ok(password)) =
+                (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
+            {
+                println!("[DEBUG] Using GIT_USERNAME and GIT_PASSWORD from environment");
+                return Cred::userpass_plaintext(&username, &password);
+            }
+
+            if url.contains("github.com") {
+                println!("[DEBUG] URL contains github.com, checking for GITHUB_TOKEN");
+                if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+                    println!("[DEBUG] Using GITHUB_TOKEN from environment");
+                    return Cred::userpass_plaintext("git", &token);
+                } else {
+                    println!("[DEBUG] GITHUB_TOKEN not found in environment");
+                }
+            }
+        }
+
+        // Default authentication (tries default SSH key)
+        if allowed_types.contains(CredentialType::DEFAULT) {
+            println!("[DEBUG] Attempting default credentials");
+            match Cred::default() {
+                Ok(cred) => {
+                    println!("[DEBUG] Default credentials succeeded");
+                    return Ok(cred);
+                }
+                Err(e) => {
+                    eprintln!("Default authentication failed: {}", e);
+                }
+            }
+        }
+
+        println!(
+            "[DEBUG] Authentication failed after {} attempts for {}. Available methods: {:?}",
+            current_attempt + 1,
+            url,
+            allowed_types
+        );
+        Err(Error::new(
+            ErrorCode::Auth,
+            ErrorClass::Net,
+            format!(
+                "Authentication failed after {} attempts for {}. Available methods: {:?}",
+                current_attempt + 1,
+                url,
+                allowed_types
+            ),
+        ))
+    });
+
+    // Set up certificate check callback for HTTPS
+    callbacks.certificate_check(|_cert, _host| {
+        println!("[DEBUG] Skipping certificate verification (INSECURE)");
+        Ok(CertificateCheckStatus::CertificateOk)
+    });
+
+    callbacks
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod git_auth;

--- a/src/workflows/default/action/mod.rs
+++ b/src/workflows/default/action/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod ta03_pop_stash;
 pub(crate) mod ta04_has_unstaged;
 pub(crate) mod ta07_has_uncommitted;
 pub(crate) mod ta08_is_pulled_pushed;
-pub(crate) mod ta09_pull_push;
 pub(crate) mod ta10_is_branch_main;
 pub(crate) mod ta11_is_sole_contributor;
 pub(crate) mod ta12_move_changes;

--- a/src/workflows/default/prompt/mod.rs
+++ b/src/workflows/default/prompt/mod.rs
@@ -11,3 +11,4 @@ pub(crate) mod pa09_ask_branch_name;
 pub(crate) mod pa10_ask_same_feat;
 pub(crate) mod pa11_ask_ai_commit_msg;
 pub(crate) mod pa12_ask_commit_msg;
+pub(crate) mod pa13_pull_push;

--- a/src/workflows/default/prompt/pa07_ask_pull_push.rs
+++ b/src/workflows/default/prompt/pa07_ask_pull_push.rs
@@ -1,11 +1,11 @@
 use crate::config::{StepFlags, WorkflowRules};
-use crate::workflows::default::action::ta09_pull_push::PullAndPush;
+use crate::step::Task::PromptStepTask;
+use crate::workflows::default::prompt::pa13_pull_push::PullAndPush;
 use crate::{
     bgit_error::{BGitError, BGitErrorWorkflowType, NO_EVENT, NO_RULE},
-    step::{ActionStep, PromptStep, Step, Task::ActionStepTask},
+    step::{PromptStep, Step},
 };
 use dialoguer::{Select, theme::ColorfulTheme};
-
 pub(crate) struct AskPushPull {
     name: String,
 }
@@ -46,7 +46,7 @@ impl PromptStep for AskPushPull {
             })?;
 
         match selection {
-            0 => Ok(Step::Task(ActionStepTask(Box::new(PullAndPush::new())))),
+            0 => Ok(Step::Task(PromptStepTask(Box::new(PullAndPush::new())))),
             1 => Ok(Step::Stop),
             _ => Err(Box::new(BGitError::new(
                 "Invalid selection",


### PR DESCRIPTION
Current implementation is a workaround working  with a `counter` to attempt different authentication steps because of the following issue.

```rs
    let key_files = [
        ("id_ed25519", "id_ed25519.pub"),
        ("id_rsa", "id_rsa.pub"),
        ("id_ecdsa", "id_ecdsa.pub"),
        ("id_dsa", "id_dsa.pub"),
    ];
```
when the first pair of files are loaded, it returns Ok(cred), which then verified by the protocol.  Before the verification of protocol as now I cannot tell whether correct pair of file is selected.

In case the verification fails by the protocol, the callback function is called again, but the function doesnt remember the previous attempt, and it will be as if its executing it for the first time, thereby  ("id_ed25519", "id_ed25519.pub"), executes again, which will again fail at protocol level, turning into a loop.
