### PR TITLE
fix: strip .git suffix from cloned repository folder names

### DIFF
--- a/src/events/git_clone.rs
+++ b/src/events/git_clone.rs
@@ -51,7 +51,7 @@ impl AtomicEvent for GitClone {
         }
         let url = &self.url;
         let repo_name = match url.split("/").last() {
-            Some(repo_name) => repo_name,
+            Some(repo_name) => repo_name.strip_suffix(".git").unwrap_or(repo_name),
             None => {
                 return Err(Box::new(BGitError::new(
                     "BGitError",
@@ -96,7 +96,7 @@ impl GitClone {
 
     fn update_cwd_path(&self) -> Result<(), Box<BGitError>> {
         let repo_name = match self.url.split("/").last() {
-            Some(repo_name) => repo_name,
+            Some(repo_name) => repo_name.strip_suffix(".git").unwrap_or(repo_name),
             None => {
                 return Err(Box::new(BGitError::new(
                     "BGitError",


### PR DESCRIPTION
When cloning repositories with .git suffix in the URL (e.g., `https://github.com/user/repo.git`), the created folder would include the .git suffix (repo.git)

Standardized repository name extraction across both raw_execute() and update_cwd_path() methods to consistently strip `.git` suffixes.